### PR TITLE
Fix Flywheel geometry showing wrong textures after a resource reload

### DIFF
--- a/src/client/java/com/zurrtum/create/client/flywheel/impl/FlwImplXplatImpl.java
+++ b/src/client/java/com/zurrtum/create/client/flywheel/impl/FlwImplXplatImpl.java
@@ -2,6 +2,7 @@ package com.zurrtum.create.client.flywheel.impl;
 
 import com.zurrtum.create.client.flywheel.backend.engine.uniform.Uniforms;
 import com.zurrtum.create.client.flywheel.lib.model.baked.ModelRenderHelper;
+import com.zurrtum.create.client.flywheel.lib.util.RendererReloadCache;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.multiplayer.ClientLevel;
 
@@ -13,6 +14,7 @@ public class FlwImplXplatImpl implements FlwImplXplat {
 
     @Override
     public void dispatchReloadLevelRendererEvent(ClientLevel level) {
+        RendererReloadCache.onReloadLevelRenderer();
         BackendManagerImpl.onReloadLevelRenderer(level);
         Uniforms.onReloadLevelRenderer();
         ModelRenderHelper.onReloadLevelRenderer();


### PR DESCRIPTION
RendererReloadCache (holding baked models with atlas UVs in their vertex data) was only cleared on initial game load, never on runtime level-renderer reload. After a resource reload, stale UVs were used if anything actually needed a re-layout, drawing all Flywheel block geometry with the wrong texture until the next full game load.

This PR fixes it by invoking the RendererReloadCache.onReloadLevelRenderer() callback in dispatchReloadLevelRendererEvent, so the UV cache is cleared on resource reload as well.

Note: this is a stopgap. The root cause is that the reload event isn't fully wired up on Fabric yet (//TODO Fabric). The proper fix would be to integrate the event-handling system on Fabric so all subscribers are notified.

Note 2: I also haven't checked whether other version branches need the same fix.