### PR TITLE
Fix contraptions disappearing on the client when joining

### DIFF
--- a/src/main/java/com/zurrtum/create/content/contraptions/ControlledContraptionEntity.java
+++ b/src/main/java/com/zurrtum/create/content/contraptions/ControlledContraptionEntity.java
@@ -169,7 +169,9 @@ public class ControlledContraptionEntity extends AbstractContraptionEntity {
         }
         IControlContraption controller = getController();
         if (controller == null) {
-            discard();
+            if (!level().isClientSide()) {
+                discard();
+            }
             return;
         }
         if (!controller.isAttachedTo(this)) {


### PR DESCRIPTION
On the client the controller isn't always ready when tickContraption() runs (e.g. when joining next to a moving contraption), so the entity discarded itself and went missing on the client entirely. Only discard server-side; the client now waits for the controller instead, like CarriageContraptionEntity does with bindCarriage().

Experienced with moving mechanical pistons and elevators.