### PR TITLE
Run client packet handlers on the main thread

### DIFF
--- a/src/client/java/com/zurrtum/create/client/AllHandle.java
+++ b/src/client/java/com/zurrtum/create/client/AllHandle.java
@@ -208,7 +208,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onTrainEditReturn(TrainEditReturnPacket packet) {
+    public void onTrainEditReturn(ClientGamePacketListener listener, TrainEditReturnPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Train train = Create.RAILWAYS.trains.get(packet.id());
         if (train == null) {
             return;
@@ -221,7 +223,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onTrainHUDControlUpdate(TrainHUDControlUpdatePacket packet) {
+    public void onTrainHUDControlUpdate(ClientGamePacketListener listener, TrainHUDControlUpdatePacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Train train = Create.RAILWAYS.trains.get(packet.trainId());
         if (train == null) {
             return;
@@ -236,7 +240,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onTrainHonkReturn(HonkReturnPacket packet) {
+    public void onTrainHonkReturn(ClientGamePacketListener listener, HonkReturnPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Train train = Create.RAILWAYS.trains.get(packet.trainId());
         if (train == null) {
             return;
@@ -266,7 +272,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onContraptionColliderLock(ContraptionColliderLockPacket packet) {
+    public void onContraptionColliderLock(ClientGamePacketListener listener, ContraptionColliderLockPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         ContraptionColliderClient.lockPacketReceived(packet.contraption(), packet.sender(), packet.offset());
     }
 
@@ -285,11 +293,14 @@ public class AllHandle extends AllClientHandle {
 
     @Override
     public void onControlsStopControlling() {
-        ControlsHandler.stopControlling(Minecraft.getInstance());
+        Minecraft mc = Minecraft.getInstance();
+        mc.execute(() -> ControlsHandler.stopControlling(mc));
     }
 
     @Override
-    public void onServerSpeed(ServerSpeedPacket packet) {
+    public void onServerSpeed(ClientGamePacketListener listener, ServerSpeedPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         if (!ServerSpeedProvider.initialized) {
             ServerSpeedProvider.initialized = true;
             ServerSpeedProvider.clientTimer = 0;
@@ -359,22 +370,28 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onContraptionStall(ContraptionStallPacket packet) {
-        if (Minecraft.getInstance().level.getEntity(packet.entityId()) instanceof AbstractContraptionEntity ce) {
+    public void onContraptionStall(ClientGamePacketListener listener, ContraptionStallPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        if (mc.level.getEntity(packet.entityId()) instanceof AbstractContraptionEntity ce) {
             ce.handleStallInformation(packet.x(), packet.y(), packet.z(), packet.angle());
         }
     }
 
     @Override
-    public void onContraptionDisassembly(ContraptionDisassemblyPacket packet) {
-        if (Minecraft.getInstance().level.getEntity(packet.entityId()) instanceof AbstractContraptionEntity ce) {
+    public void onContraptionDisassembly(ClientGamePacketListener listener, ContraptionDisassemblyPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        if (mc.level.getEntity(packet.entityId()) instanceof AbstractContraptionEntity ce) {
             ce.moveCollidedEntitiesOnDisassembly(packet.transform());
         }
     }
 
     @Override
-    public void onContraptionBlockChanged(ContraptionBlockChangedPacket packet) {
-        if (Minecraft.getInstance().level.getEntity(packet.entityId()) instanceof AbstractContraptionEntity ce) {
+    public void onContraptionBlockChanged(ClientGamePacketListener listener, ContraptionBlockChangedPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        if (mc.level.getEntity(packet.entityId()) instanceof AbstractContraptionEntity ce) {
             Contraption contraption = ce.getContraption();
             if (contraption == null) {
                 return;
@@ -406,8 +423,10 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onContraptionSeatMapping(ContraptionSeatMappingPacket packet) {
-        LocalPlayer player = Minecraft.getInstance().player;
+    public void onContraptionSeatMapping(ClientGamePacketListener listener, ContraptionSeatMappingPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        LocalPlayer player = mc.player;
         Entity entityByID = player.level().getEntity(packet.entityId());
         if (!(entityByID instanceof AbstractContraptionEntity contraptionEntity)) {
             return;
@@ -450,8 +469,10 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onMountedStorageSync(MountedStorageSyncPacket packet) {
-        Entity entity = Minecraft.getInstance().level.getEntity(packet.contraptionId());
+    public void onMountedStorageSync(ClientGamePacketListener listener, MountedStorageSyncPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        Entity entity = mc.level.getEntity(packet.contraptionId());
         if (!(entity instanceof AbstractContraptionEntity contraption)) {
             return;
         }
@@ -460,8 +481,10 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onGantryContraptionUpdate(GantryContraptionUpdatePacket packet) {
-        Entity entity = Minecraft.getInstance().level.getEntity(packet.entityID());
+    public void onGantryContraptionUpdate(ClientGamePacketListener listener, GantryContraptionUpdatePacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        Entity entity = mc.level.getEntity(packet.entityID());
         if (!(entity instanceof GantryContraptionEntity ce)) {
             return;
         }
@@ -471,8 +494,10 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onHighlight(HighlightPacket packet) {
-        if (!Minecraft.getInstance().level.isLoaded(packet.pos())) {
+    public void onHighlight(ClientGamePacketListener listener, HighlightPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        if (!mc.level.isLoaded(packet.pos())) {
             return;
         }
 
@@ -483,8 +508,10 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onTunnelFlap(TunnelFlapPacket packet) {
-        if (Minecraft.getInstance().level.getBlockEntity(packet.pos()) instanceof BeltTunnelBlockEntity blockEntity) {
+    public void onTunnelFlap(ClientGamePacketListener listener, TunnelFlapPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        if (mc.level.getBlockEntity(packet.pos()) instanceof BeltTunnelBlockEntity blockEntity) {
             packet.flaps().forEach(flap -> {
                 blockEntity.flap(flap.getFirst(), flap.getSecond());
             });
@@ -501,7 +528,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onSoulPulseEffect(SoulPulseEffectPacket packet) {
+    public void onSoulPulseEffect(ClientGamePacketListener listener, SoulPulseEffectPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Create.SOUL_PULSE_EFFECT_HANDLER.addPulse(new SoulPulseEffect(
             packet.pos(),
             packet.distance(),
@@ -510,7 +539,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onSignalEdgeGroup(SignalEdgeGroupPacket packet) {
+    public void onSignalEdgeGroup(ClientGamePacketListener listener, SignalEdgeGroupPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Map<UUID, SignalEdgeGroup> signalEdgeGroups = Create.RAILWAYS.signalEdgeGroups;
         List<UUID> ids = packet.ids();
         for (int i = 0; i < ids.size(); i++) {
@@ -529,7 +560,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onRemoveTrain(RemoveTrainPacket packet) {
+    public void onRemoveTrain(ClientGamePacketListener listener, RemoveTrainPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Create.RAILWAYS.trains.remove(packet.id());
     }
 
@@ -548,21 +581,27 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onTrainPrompt(TrainPromptPacket packet) {
+    public void onTrainPrompt(ClientGamePacketListener listener, TrainPromptPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         TrainHUD.currentPrompt = packet.text();
         TrainHUD.currentPromptShadow = packet.shadow();
         TrainHUD.promptKeepAlive = 30;
     }
 
     @Override
-    public void onContraptionRelocation(ContraptionRelocationPacket packet) {
-        if (Minecraft.getInstance().level.getEntity(packet.entityId()) instanceof OrientedContraptionEntity oce) {
+    public void onContraptionRelocation(ClientGamePacketListener listener, ContraptionRelocationPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        if (mc.level.getEntity(packet.entityId()) instanceof OrientedContraptionEntity oce) {
             oce.nonDamageTicks = 10;
         }
     }
 
     @Override
-    public void onTrackGraphRollCall(TrackGraphRollCallPacket packet) {
+    public void onTrackGraphRollCall(ClientGamePacketListener listener, TrackGraphRollCallPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         GlobalRailwayManager manager = Create.RAILWAYS;
         Set<UUID> unusedIds = new HashSet<>(manager.trackNetworks.keySet());
         List<Integer> failedIds = new ArrayList<>();
@@ -584,7 +623,7 @@ public class AllHandle extends AllClientHandle {
             failedIds.add(entry.netId());
         }
 
-        ClientPacketListener networkHandler = Minecraft.getInstance().player.connection;
+        ClientPacketListener networkHandler = mc.player.connection;
         for (Integer failed : failedIds) {
             networkHandler.send(new TrackGraphRequestPacket(failed));
         }
@@ -594,18 +633,24 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onArmPlacementRequest(ArmPlacementRequestPacket packet) {
-        ArmInteractionPointHandler.flushSettings(Minecraft.getInstance().player, packet.pos());
+    public void onArmPlacementRequest(ClientGamePacketListener listener, ArmPlacementRequestPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        ArmInteractionPointHandler.flushSettings(mc.player, packet.pos());
     }
 
     @Override
-    public void onEjectorPlacementRequest(EjectorPlacementRequestPacket packet) {
+    public void onEjectorPlacementRequest(ClientGamePacketListener listener, EjectorPlacementRequestPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         EjectorTargetHandler.flushSettings(packet.pos());
     }
 
     @Override
-    public void onPackagePortPlacementRequest(PackagePortPlacementRequestPacket packet) {
-        PackagePortTargetSelectionHandler.flushSettings(Minecraft.getInstance().player, packet.pos());
+    public void onPackagePortPlacementRequest(ClientGamePacketListener listener, PackagePortPlacementRequestPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
+        PackagePortTargetSelectionHandler.flushSettings(mc.player, packet.pos());
     }
 
     @Override
@@ -648,11 +693,12 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onServerDebugInfo(ServerDebugInfoPacket packet) {
+    public void onServerDebugInfo(ClientGamePacketListener listener, ServerDebugInfoPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         StringBuilder output = new StringBuilder();
         List<DebugInfoSection> clientInfo = DebugInformation.getClientInfo();
 
-        Minecraft mc = Minecraft.getInstance();
         ServerDebugInfoPacket.printInfo("Client", mc.player, clientInfo, output);
         output.append("\n\n");
         output.append(packet.serverInfo());
@@ -710,7 +756,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onClientboundChainConveyorRiding(ClientboundChainConveyorRidingPacket packet) {
+    public void onClientboundChainConveyorRiding(ClientGamePacketListener listener, ClientboundChainConveyorRidingPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         PlayerSkyhookRenderer.updatePlayerList(packet.uuids());
     }
 
@@ -728,7 +776,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onTrackGraphSync(TrackGraphSyncPacket packet) {
+    public void onTrackGraphSync(ClientGamePacketListener listener, TrackGraphSyncPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         GlobalRailwayManager manager = Create.RAILWAYS;
         TrackGraph graph = manager.getOrCreateGraph(packet.graphId, packet.netId);
         manager.version++;
@@ -827,7 +877,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onAddTrain(AddTrainPacket packet) {
+    public void onAddTrain(ClientGamePacketListener listener, AddTrainPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         Train train = packet.train();
         Create.RAILWAYS.trains.put(train.id, train);
     }
@@ -847,7 +899,9 @@ public class AllHandle extends AllClientHandle {
     }
 
     @Override
-    public void onBlueprintPreview(BlueprintPreviewPacket packet) {
+    public void onBlueprintPreview(ClientGamePacketListener listener, BlueprintPreviewPacket packet) {
+        Minecraft mc = Minecraft.getInstance();
+        forceMainThread(listener, mc, packet);
         BlueprintOverlayRenderer.updatePreview(packet.available(), packet.missing(), packet.result());
     }
 

--- a/src/main/java/com/zurrtum/create/AllClientHandle.java
+++ b/src/main/java/com/zurrtum/create/AllClientHandle.java
@@ -67,15 +67,15 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onTrainEditReturn(TrainEditReturnPacket packet) {
+    public void onTrainEditReturn(ClientGamePacketListener listener, TrainEditReturnPacket packet) {
         warn();
     }
 
-    public void onTrainHUDControlUpdate(TrainHUDControlUpdatePacket packet) {
+    public void onTrainHUDControlUpdate(ClientGamePacketListener listener, TrainHUDControlUpdatePacket packet) {
         warn();
     }
 
-    public void onTrainHonkReturn(HonkReturnPacket packet) {
+    public void onTrainHonkReturn(ClientGamePacketListener listener, HonkReturnPacket packet) {
         warn();
     }
 
@@ -83,7 +83,7 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onContraptionColliderLock(ContraptionColliderLockPacket packet) {
+    public void onContraptionColliderLock(ClientGamePacketListener listener, ContraptionColliderLockPacket packet) {
         warn();
     }
 
@@ -95,7 +95,7 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onServerSpeed(ServerSpeedPacket packet) {
+    public void onServerSpeed(ClientGamePacketListener listener, ServerSpeedPacket packet) {
         warn();
     }
 
@@ -103,15 +103,15 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onContraptionStall(ContraptionStallPacket packet) {
+    public void onContraptionStall(ClientGamePacketListener listener, ContraptionStallPacket packet) {
         warn();
     }
 
-    public void onContraptionDisassembly(ContraptionDisassemblyPacket packet) {
+    public void onContraptionDisassembly(ClientGamePacketListener listener, ContraptionDisassemblyPacket packet) {
         warn();
     }
 
-    public void onContraptionBlockChanged(ContraptionBlockChangedPacket packet) {
+    public void onContraptionBlockChanged(ClientGamePacketListener listener, ContraptionBlockChangedPacket packet) {
         warn();
     }
 
@@ -119,7 +119,7 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onContraptionSeatMapping(ContraptionSeatMappingPacket packet) {
+    public void onContraptionSeatMapping(ClientGamePacketListener listener, ContraptionSeatMappingPacket packet) {
         warn();
     }
 
@@ -127,19 +127,19 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onMountedStorageSync(MountedStorageSyncPacket packet) {
+    public void onMountedStorageSync(ClientGamePacketListener listener, MountedStorageSyncPacket packet) {
         warn();
     }
 
-    public void onGantryContraptionUpdate(GantryContraptionUpdatePacket packet) {
+    public void onGantryContraptionUpdate(ClientGamePacketListener listener, GantryContraptionUpdatePacket packet) {
         warn();
     }
 
-    public void onHighlight(HighlightPacket packet) {
+    public void onHighlight(ClientGamePacketListener listener, HighlightPacket packet) {
         warn();
     }
 
-    public void onTunnelFlap(TunnelFlapPacket packet) {
+    public void onTunnelFlap(ClientGamePacketListener listener, TunnelFlapPacket packet) {
         warn();
     }
 
@@ -151,15 +151,15 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onSoulPulseEffect(SoulPulseEffectPacket packet) {
+    public void onSoulPulseEffect(ClientGamePacketListener listener, SoulPulseEffectPacket packet) {
         warn();
     }
 
-    public void onSignalEdgeGroup(SignalEdgeGroupPacket packet) {
+    public void onSignalEdgeGroup(ClientGamePacketListener listener, SignalEdgeGroupPacket packet) {
         warn();
     }
 
-    public void onRemoveTrain(RemoveTrainPacket packet) {
+    public void onRemoveTrain(ClientGamePacketListener listener, RemoveTrainPacket packet) {
         warn();
     }
 
@@ -167,27 +167,27 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onTrainPrompt(TrainPromptPacket packet) {
+    public void onTrainPrompt(ClientGamePacketListener listener, TrainPromptPacket packet) {
         warn();
     }
 
-    public void onContraptionRelocation(ContraptionRelocationPacket packet) {
+    public void onContraptionRelocation(ClientGamePacketListener listener, ContraptionRelocationPacket packet) {
         warn();
     }
 
-    public void onTrackGraphRollCall(TrackGraphRollCallPacket packet) {
+    public void onTrackGraphRollCall(ClientGamePacketListener listener, TrackGraphRollCallPacket packet) {
         warn();
     }
 
-    public void onArmPlacementRequest(ArmPlacementRequestPacket packet) {
+    public void onArmPlacementRequest(ClientGamePacketListener listener, ArmPlacementRequestPacket packet) {
         warn();
     }
 
-    public void onEjectorPlacementRequest(EjectorPlacementRequestPacket packet) {
+    public void onEjectorPlacementRequest(ClientGamePacketListener listener, EjectorPlacementRequestPacket packet) {
         warn();
     }
 
-    public void onPackagePortPlacementRequest(PackagePortPlacementRequestPacket packet) {
+    public void onPackagePortPlacementRequest(ClientGamePacketListener listener, PackagePortPlacementRequestPacket packet) {
         warn();
     }
 
@@ -199,7 +199,7 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onServerDebugInfo(ServerDebugInfoPacket packet) {
+    public void onServerDebugInfo(ClientGamePacketListener listener, ServerDebugInfoPacket packet) {
         warn();
     }
 
@@ -215,7 +215,7 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onClientboundChainConveyorRiding(ClientboundChainConveyorRidingPacket packet) {
+    public void onClientboundChainConveyorRiding(ClientGamePacketListener listener, ClientboundChainConveyorRidingPacket packet) {
         warn();
     }
 
@@ -223,11 +223,11 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onTrackGraphSync(TrackGraphSyncPacket packet) {
+    public void onTrackGraphSync(ClientGamePacketListener listener, TrackGraphSyncPacket packet) {
         warn();
     }
 
-    public void onAddTrain(AddTrainPacket packet) {
+    public void onAddTrain(ClientGamePacketListener listener, AddTrainPacket packet) {
         warn();
     }
 
@@ -235,7 +235,7 @@ public class AllClientHandle {
         warn();
     }
 
-    public void onBlueprintPreview(BlueprintPreviewPacket packet) {
+    public void onBlueprintPreview(ClientGamePacketListener listener, BlueprintPreviewPacket packet) {
         warn();
     }
 

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/AddTrainPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/AddTrainPacket.java
@@ -16,7 +16,7 @@ public record AddTrainPacket(Train train) implements Packet<ClientGamePacketList
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onAddTrain(this);
+        AllClientHandle.INSTANCE.onAddTrain(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ArmPlacementRequestPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ArmPlacementRequestPacket.java
@@ -16,7 +16,7 @@ public record ArmPlacementRequestPacket(BlockPos pos) implements Packet<ClientGa
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onArmPlacementRequest(this);
+        AllClientHandle.INSTANCE.onArmPlacementRequest(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/BlueprintPreviewPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/BlueprintPreviewPacket.java
@@ -77,7 +77,7 @@ public record BlueprintPreviewPacket(List<ItemStack> available, List<ItemStack> 
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onBlueprintPreview(this);
+        AllClientHandle.INSTANCE.onBlueprintPreview(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ClientboundChainConveyorRidingPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ClientboundChainConveyorRidingPacket.java
@@ -23,7 +23,7 @@ public record ClientboundChainConveyorRidingPacket(Collection<UUID> uuids) imple
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onClientboundChainConveyorRiding(this);
+        AllClientHandle.INSTANCE.onClientboundChainConveyorRiding(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionBlockChangedPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionBlockChangedPacket.java
@@ -26,7 +26,7 @@ public record ContraptionBlockChangedPacket(int entityId, BlockPos localPos,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onContraptionBlockChanged(this);
+        AllClientHandle.INSTANCE.onContraptionBlockChanged(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionColliderLockPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionColliderLockPacket.java
@@ -23,7 +23,7 @@ public record ContraptionColliderLockPacket(int contraption, double offset,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onContraptionColliderLock(this);
+        AllClientHandle.INSTANCE.onContraptionColliderLock(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionDisassemblyPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionDisassemblyPacket.java
@@ -22,7 +22,7 @@ public record ContraptionDisassemblyPacket(int entityId,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onContraptionDisassembly(this);
+        AllClientHandle.INSTANCE.onContraptionDisassembly(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionRelocationPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionRelocationPacket.java
@@ -16,7 +16,7 @@ public record ContraptionRelocationPacket(int entityId) implements Packet<Client
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onContraptionRelocation(this);
+        AllClientHandle.INSTANCE.onContraptionRelocation(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionSeatMappingPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionSeatMappingPacket.java
@@ -36,7 +36,7 @@ public record ContraptionSeatMappingPacket(int entityId, Map<UUID, Integer> mapp
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onContraptionSeatMapping(this);
+        AllClientHandle.INSTANCE.onContraptionSeatMapping(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionStallPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ContraptionStallPacket.java
@@ -27,7 +27,7 @@ public record ContraptionStallPacket(int entityId, double x, double y, double z,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onContraptionStall(this);
+        AllClientHandle.INSTANCE.onContraptionStall(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/EjectorPlacementRequestPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/EjectorPlacementRequestPacket.java
@@ -16,7 +16,7 @@ public record EjectorPlacementRequestPacket(BlockPos pos) implements Packet<Clie
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onEjectorPlacementRequest(this);
+        AllClientHandle.INSTANCE.onEjectorPlacementRequest(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/GantryContraptionUpdatePacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/GantryContraptionUpdatePacket.java
@@ -25,7 +25,7 @@ public record GantryContraptionUpdatePacket(int entityID, double coord, double m
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onGantryContraptionUpdate(this);
+        AllClientHandle.INSTANCE.onGantryContraptionUpdate(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/HighlightPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/HighlightPacket.java
@@ -17,7 +17,7 @@ public record HighlightPacket(BlockPos pos) implements Packet<ClientGamePacketLi
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onHighlight(this);
+        AllClientHandle.INSTANCE.onHighlight(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/HonkReturnPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/HonkReturnPacket.java
@@ -28,7 +28,7 @@ public record HonkReturnPacket(UUID trainId, boolean isHonk) implements Packet<C
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTrainHonkReturn(this);
+        AllClientHandle.INSTANCE.onTrainHonkReturn(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/MountedStorageSyncPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/MountedStorageSyncPacket.java
@@ -29,7 +29,7 @@ public record MountedStorageSyncPacket(int contraptionId, Map<BlockPos, MountedI
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onMountedStorageSync(this);
+        AllClientHandle.INSTANCE.onMountedStorageSync(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/PackagePortPlacementRequestPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/PackagePortPlacementRequestPacket.java
@@ -16,7 +16,7 @@ public record PackagePortPlacementRequestPacket(BlockPos pos) implements Packet<
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onPackagePortPlacementRequest(this);
+        AllClientHandle.INSTANCE.onPackagePortPlacementRequest(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/RemoveTrainPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/RemoveTrainPacket.java
@@ -24,7 +24,7 @@ public record RemoveTrainPacket(UUID id) implements Packet<ClientGamePacketListe
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onRemoveTrain(this);
+        AllClientHandle.INSTANCE.onRemoveTrain(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ServerDebugInfoPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ServerDebugInfoPacket.java
@@ -53,7 +53,7 @@ public record ServerDebugInfoPacket(String serverInfo) implements Packet<ClientG
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onServerDebugInfo(this);
+        AllClientHandle.INSTANCE.onServerDebugInfo(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ServerSpeedPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/ServerSpeedPacket.java
@@ -17,7 +17,7 @@ public record ServerSpeedPacket(int speed) implements Packet<ClientGamePacketLis
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onServerSpeed(this);
+        AllClientHandle.INSTANCE.onServerSpeed(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/SignalEdgeGroupPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/SignalEdgeGroupPacket.java
@@ -34,7 +34,7 @@ public record SignalEdgeGroupPacket(List<UUID> ids, List<EdgeGroupColor> colors,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onSignalEdgeGroup(this);
+        AllClientHandle.INSTANCE.onSignalEdgeGroup(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/SoulPulseEffectPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/SoulPulseEffectPacket.java
@@ -24,7 +24,7 @@ public record SoulPulseEffectPacket(BlockPos pos, int distance,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onSoulPulseEffect(this);
+        AllClientHandle.INSTANCE.onSoulPulseEffect(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrackGraphRollCallPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrackGraphRollCallPacket.java
@@ -29,7 +29,7 @@ public record TrackGraphRollCallPacket(List<Entry> entries) implements Packet<Cl
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTrackGraphRollCall(this);
+        AllClientHandle.INSTANCE.onTrackGraphRollCall(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrackGraphSyncPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrackGraphSyncPacket.java
@@ -24,7 +24,7 @@ public class TrackGraphSyncPacket extends TrackGraphPacket {
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTrackGraphSync(this);
+        AllClientHandle.INSTANCE.onTrackGraphSync(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrainEditReturnPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrainEditReturnPacket.java
@@ -29,7 +29,7 @@ public record TrainEditReturnPacket(UUID id, String name, Identifier iconType,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTrainEditReturn(this);
+        AllClientHandle.INSTANCE.onTrainEditReturn(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrainHUDControlUpdatePacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrainHUDControlUpdatePacket.java
@@ -40,7 +40,7 @@ public record TrainHUDControlUpdatePacket(UUID trainId, @Nullable Double throttl
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTrainHUDControlUpdate(this);
+        AllClientHandle.INSTANCE.onTrainHUDControlUpdate(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrainPromptPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TrainPromptPacket.java
@@ -22,7 +22,7 @@ public record TrainPromptPacket(Component text, boolean shadow) implements Packe
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTrainPrompt(this);
+        AllClientHandle.INSTANCE.onTrainPrompt(listener, this);
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TunnelFlapPacket.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/packet/s2c/TunnelFlapPacket.java
@@ -33,7 +33,7 @@ public record TunnelFlapPacket(BlockPos pos,
 
     @Override
     public void handle(ClientGamePacketListener listener) {
-        AllClientHandle.INSTANCE.onTunnelFlap(this);
+        AllClientHandle.INSTANCE.onTunnelFlap(listener, this);
     }
 
     @Override


### PR DESCRIPTION
Create Fly would sometimes try to call code on a null level in its packet handlers. This happens because the level isn't necessarily loaded at this point in time. Some handlers also mutated non-thread-safe shared state, which could race with the main thread.

This puts packet handling on the main thread (like most other handlers already do), preventing data races and ensuring the level is loaded BEFORE the code is executed.

The error this PR fixes is game-breaking since it leads to clients being kicked from the server with NullPtrExceptions. Because of this, I would appreciate it if you could release it for 26.1.2 too, not only for 26.2. I'm running 26.1 and specifically fixed it there because I depend on it. If you do this, consider merging my other PRs #316 and #325 into 26.1.2 too, before releasing it (they are based on 26.1 as well).