### PR TITLE
Fix mechanical mixer rendering before behaviour initialization

### DIFF
--- a/src/client/java/com/zurrtum/create/client/content/kinetics/mixer/MechanicalMixerRenderer.java
+++ b/src/client/java/com/zurrtum/create/client/content/kinetics/mixer/MechanicalMixerRenderer.java
@@ -63,7 +63,19 @@ public class MechanicalMixerRenderer implements BlockEntityRenderer<MechanicalMi
             .cardinalLighting(cardinalLighting).light(state.lightCoords).extractRenderState();
         MechanicalMixerAnimationBehaviour behaviour = (MechanicalMixerAnimationBehaviour) be.getBehaviour(
             AnimationBehaviour.TYPE);
-        state.headAngle = getRotateAngle(progress, behaviour.getOffset(speed, tickProgress), Direction.UP);
+        state.headAngle = getRotateAngle(
+            progress,
+            getHeadRotationOffset(behaviour, speed, tickProgress),
+            Direction.UP
+        );
+    }
+
+    static float getHeadRotationOffset(
+        @Nullable MechanicalMixerAnimationBehaviour behaviour,
+        float speed,
+        float tickProgress
+    ) {
+        return behaviour == null ? 0 : behaviour.getOffset(speed, tickProgress);
     }
 
     public static float getRenderedHeadOffset(MechanicalMixerBlockEntity be, float partialTicks) {

--- a/src/client/java/com/zurrtum/create/client/content/kinetics/mixer/MixerVisual.java
+++ b/src/client/java/com/zurrtum/create/client/content/kinetics/mixer/MixerVisual.java
@@ -64,7 +64,7 @@ public class MixerVisual extends SingleAxisRotatingVisual<MechanicalMixerBlockEn
         float speed = blockEntity.getSpeed();
         mixerHead.setPosition(getVisualPosition()).nudge(0, renderedHeadOffset, 0)
             .setRotationalSpeed(speed * RotatingInstance.SPEED_MULTIPLIER)
-            .setRotationOffset(behaviour.getOffset(speed, pt)).setChanged();
+            .setRotationOffset(MechanicalMixerRenderer.getHeadRotationOffset(behaviour, speed, pt)).setChanged();
     }
 
     private void transformPole(float renderedHeadOffset) {


### PR DESCRIPTION
## Summary

Prevent mechanical mixer rendering from crashing when its client animation behaviour has not been initialized yet.

Client behaviours are registered during the first block entity tick, while the vanilla renderer or Flywheel visual may access the block entity before that. In this state, `getBehaviour(AnimationBehaviour.TYPE)` returns `null`.

This regression was introduced when mixer rendering was migrated to `MechanicalMixerAnimationBehaviour` in commit `50139bfa4e6b31e65df6d36e1c89aadcd74ecd92` (`Update SuperByteBuffer`).

## Changes

- Fall back to a zero rotation offset until the animation behaviour is available.
- Apply the same handling to both the vanilla renderer and Flywheel visual paths.

## Crash Evidence

The crash report attached to #328 shows:

```text
java.lang.NullPointerException: Cannot invoke
"com.zurrtum.create.client.foundation.blockEntity.behaviour.animation.MechanicalMixerAnimationBehaviour.getOffset(float, float)"
because "behaviour" is null

at knot//com.zurrtum.create.client.content.kinetics.mixer.MechanicalMixerRenderer.extractRenderState(MechanicalMixerRenderer.java:66)
at knot//com.zurrtum.create.client.content.kinetics.mixer.MechanicalMixerRenderer.extractRenderState(MechanicalMixerRenderer.java:32)
at knot//net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher.tryExtractRenderState(BlockEntityRenderDispatcher.java:82)
at knot//net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer.extractBlockEntity(SodiumWorldRenderer.java:401)
```

The report is from Minecraft `26.1.2` with Create Fly `6.0.9-4`. The same missing-behaviour access exists in the `26.2` renderer and Flywheel visual paths fixed by this change.

On Minecraft `26.2`, the same bug usually presents differently. The exception is thrown from the Flywheel worker thread while creating `MixerVisual`, so the main render thread does not immediately crash. Instead, the log contains `Error running task` with the following path:

```text
[Flywheel Task Executor #7/ERROR]: Error running task
at ...MixerVisual.transformHead(MixerVisual.java:67)
at ...MixerVisual.animate(MixerVisual.java:58)
at ...MixerVisual.<init>(MixerVisual.java:41)
```

Depending on the rendering state and timing, the mechanical mixer may fail to render, fail to animate, render only partially, or leave a stale/duplicate visual after the block is placed or removed. In the reported 26.2 session, the player observed that mixers could not be placed correctly with shaders enabled, and later observed leftover visuals and two overlapping mixer shadows. The same log also recorded the client shutdown watchdog after leaving the world; that is a separate Flywheel worker-lifecycle issue and is not part of this PR.

## Related Issue

Related to #328.
