### PR TITLE
feat: Port REI compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
     addGroup("https://maven.squiddev.cc", "cc.tweaked")
     addGroup("https://maven.nucleoid.xyz/releases", "eu.pb4")
     addGroup("https://api.modrinth.com/maven", "maven.modrinth")
+    addGroup("https://maven.shedaniel.me", "me.shedaniel", "dev.architectury", "me.shedaniel.cloth")
 }
 
 version = "$project.mod_version-$project.mod_id"
@@ -45,14 +46,11 @@ loom {
 sourceSets {
     main {
         java {
-            exclude 'com/zurrtum/create/compat/rei/**'
             exclude 'com/zurrtum/create/compat/eiv/**'
-            exclude 'com/zurrtum/create/mixin/ArchitecturyMixin.java'
         }
     }
     client {
         java {
-            exclude 'com/zurrtum/create/client/compat/rei/**'
             exclude 'com/zurrtum/create/client/compat/eiv/**'
             exclude 'com/zurrtum/create/client/mixin/CraftingViewRecipeAccessor.java'
             exclude 'com/zurrtum/create/client/mixin/FabricEIVMixin.java'
@@ -97,10 +95,12 @@ dependencies {
     } else {
         implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     }
-//    modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
-//    if (project.compile_only_rei.equals("false")) {
-//        modClientRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
-//    }
+    compileOnly "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config}"
+    compileOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
+    compileOnly "dev.architectury:architectury-fabric:${project.architectury_api}"
+    if (project.compile_only_rei.equals("false")) {
+        clientRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
+    }
     clientCompileOnly "mezz.jei:jei-${project.jei_version}"
 //    modCompileOnly "maven.modrinth:eiv:${project.eiv_version}"
     clientCompileOnly "cc.cassian.rrv:reliable-recipe-viewer-fabric:${rrv_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,10 +16,14 @@ fabric_version                 = 0.152.0+26.2
 
 # Recipe Viewer
 compile_only_rei               = true
-rei_version                    = 20.0.811
+rei_version                    = 26.2.820
 jei_version                    = 26.1.2-fabric:29.6.2.31
 eiv_version                    = 5.2.0+1.21.10
 rrv_version                    = 8.3.1+26.2-pre-5
+
+# Rei dependencies
+cloth_config                   = 26.2.155
+architectury_api               = 21.0.6
 
 # Sodium
 sodium_version                 = mc26.1.2-0.8.12-beta.2-fabric

--- a/src/client/java/com/zurrtum/create/client/compat/rei/CreateCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/CreateCategory.java
@@ -79,9 +79,9 @@ public abstract class CreateCategory<T extends Display> implements DisplayCatego
     public static EntryIngredient getRenderEntryStack(ProcessingOutput output) {
         float chance = output.chance();
         if (chance == 1) {
-            return EntryIngredients.of(output.stack());
+            return EntryIngredients.of(output.create());
         }
-        EntryStack<ItemStack> stack = EntryStacks.of(output.stack());
+        EntryStack<ItemStack> stack = EntryStacks.of(output.create());
         stack.withRenderer(new ChanceItemRenderer(chance, stack.getRenderer()));
         return EntryIngredient.of(stack);
     }

--- a/src/client/java/com/zurrtum/create/client/compat/rei/ReiClientPlugin.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/ReiClientPlugin.java
@@ -10,8 +10,6 @@ import com.zurrtum.create.client.foundation.gui.menu.AbstractSimiContainerScreen
 import com.zurrtum.create.compat.rei.display.DrainingDisplay;
 import com.zurrtum.create.compat.rei.display.SpoutFillingDisplay;
 import me.shedaniel.math.Rectangle;
-import me.shedaniel.rei.api.client.REIRuntime;
-import me.shedaniel.rei.api.client.gui.widgets.TextField;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry.CategoryConfiguration;
@@ -107,7 +105,7 @@ public class ReiClientPlugin implements REIClientPlugin {
         EntryIngredient ingredient = EntryIngredients.ofItemTag(AllItemTags.TOOLBOXES);
         for (DyeColor color : DyeColor.values()) {
             registry.add(new ClientsidedCraftingDisplay.Shapeless(
-                List.of(ingredient, EntryIngredients.of(DyeItem.byColor(color))),
+                List.of(ingredient, EntryIngredients.of(DyeItem.byId(color.getId()))),
                 List.of(EntryIngredients.of(AllBlocks.TOOLBOX.pick(color))),
                 Optional.empty()
             ));
@@ -134,13 +132,6 @@ public class ReiClientPlugin implements REIClientPlugin {
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void registerInputMethods(InputMethodRegistry registry) {
-        StockKeeperRequestScreen.setSearchConsumer(ReiClientPlugin::setSearchField);
-    }
-
-    public static void setSearchField(String text) {
-        TextField search = REIRuntime.getInstance().getSearchTextField();
-        if (search != null) {
-            search.setText(text);
-        }
+        StockKeeperRequestScreen.setSearchSync(new ReiStockSearchSync());
     }
 }

--- a/src/client/java/com/zurrtum/create/client/compat/rei/ReiStockSearchSync.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/ReiStockSearchSync.java
@@ -1,0 +1,31 @@
+package com.zurrtum.create.client.compat.rei;
+
+import com.zurrtum.create.client.content.logistics.stockTicker.StockSearchSync;
+import me.shedaniel.rei.api.client.REIRuntime;
+import me.shedaniel.rei.api.client.gui.widgets.TextField;
+import org.jspecify.annotations.Nullable;
+
+public class ReiStockSearchSync implements StockSearchSync {
+    @Override
+    public boolean slotSync() {
+        return false;
+    }
+
+    @Override
+    public void set(String value) {
+        TextField search = REIRuntime.getInstance().getSearchTextField();
+        if (search != null) {
+            search.setText(value);
+        }
+    }
+
+    @Override
+    public @Nullable String get(boolean force) {
+        TextField search = REIRuntime.getInstance().getSearchTextField();
+        if (search != null) {
+            return search.getText();
+        }
+
+        return null;
+    }
+}

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/AutoCompactingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/AutoCompactingCategory.java
@@ -10,12 +10,12 @@ import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.plugin.common.displays.crafting.CraftingDisplay;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -47,7 +47,7 @@ public class AutoCompactingCategory extends CreateCategory<CraftingDisplay> {
             points.add(new Point(bounds.x + 5 + (rows == 2 ? 27 : 18) + i % rows * 19, bounds.y + 56 - i / rows * 19));
         }
         Point output = new Point(bounds.x + 147, bounds.y + 56);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, points, output);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 141, bounds.y + 37);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 86, bounds.y + 73);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/AutoMixingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/AutoMixingCategory.java
@@ -10,12 +10,12 @@ import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.plugin.common.displays.crafting.CraftingDisplay;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -47,7 +47,7 @@ public class AutoMixingCategory extends CreateCategory<CraftingDisplay> {
             points.add(new Point(bounds.x + 17 + xOffset + i % 3 * 19, bounds.y + 56 - i / 3 * 19));
         }
         Point output = new Point(bounds.x + 147, bounds.y + 56);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, points, output);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 141, bounds.y + 37);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 86, bounds.y + 73);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/BlockCuttingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/BlockCuttingCategory.java
@@ -11,11 +11,11 @@ import com.zurrtum.create.compat.rei.display.BlockCuttingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -47,7 +47,7 @@ public class BlockCuttingCategory extends CreateCategory<BlockCuttingDisplay> {
         for (int i = 0, left = bounds.x + 83, top = bounds.y + 53; i < size; i++) {
             outputs[i] = new Point(left + i % 5 * 19, top + i / 5 * -19);
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input);
             drawSlotBackground(graphics, outputs);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 36, bounds.y + 11);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/CompactingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/CompactingCategory.java
@@ -11,11 +11,11 @@ import com.zurrtum.create.compat.rei.display.CompactingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -46,7 +46,7 @@ public class CompactingCategory extends CreateCategory<CompactingDisplay> {
             points.add(new Point(bounds.x + 17 + xOffset + i % 3 * 19, bounds.y + 56 - i / 3 * 19));
         }
         Point output = new Point(bounds.x + 147, bounds.y + 56);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, points);
             AllGuiTextures.JEI_SLOT.render(graphics, output.x - 1, output.y - 1);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 141, bounds.y + 37);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/CrushingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/CrushingCategory.java
@@ -12,11 +12,11 @@ import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -51,7 +51,7 @@ public class CrushingCategory extends CreateCategory<CrushingDisplay> {
             ProcessingOutput output = results.get(i);
             addOutputData(output, start + i * 19, y, outputs, outputIngredients, chances, chanceIngredients);
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, outputs, input);
             drawChanceSlotBackground(graphics, chances);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 77, bounds.y + 12);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/DeployingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/DeployingCategory.java
@@ -10,11 +10,11 @@ import com.zurrtum.create.compat.rei.display.DeployingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -41,7 +41,7 @@ public class DeployingCategory extends CreateCategory<DeployingDisplay> {
         Point input = new Point(bounds.x + 56, bounds.y + 10);
         Point target = new Point(bounds.x + 32, bounds.y + 56);
         Point output = new Point(bounds.x + 137, bounds.y + 56);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, target, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 67, bounds.y + 62);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 131, bounds.y + 34);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/DrainingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/DrainingCategory.java
@@ -12,12 +12,12 @@ import dev.architectury.fluid.FluidStack;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Slot;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryStack;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -46,7 +46,7 @@ public class DrainingCategory extends CreateCategory<DrainingDisplay> {
         Point output = new Point(bounds.x + 137, bounds.y + 13);
         Point result = new Point(bounds.x + 137, bounds.y + 32);
         Slot fluidSlot = createOutputSlot(output).entries(getRenderEntryStack(display.output()));
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output, result);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 67, bounds.y + 42);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 78, bounds.y + 9);
@@ -55,7 +55,7 @@ public class DrainingCategory extends CreateCategory<DrainingDisplay> {
             graphics.guiRenderState.addPicturesInPictureState(new DrainRenderState(
                 new Matrix3x2f(graphics.pose()),
                 stack.getFluid(),
-                stack.getComponents().asPatch(),
+                stack.getPatch(),
                 bounds.x + 80,
                 bounds.y + 28
             ));

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/FanBlastingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/FanBlastingCategory.java
@@ -11,10 +11,10 @@ import com.zurrtum.create.compat.rei.display.FanBlastingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.material.Fluids;
@@ -42,7 +42,7 @@ public class FanBlastingCategory extends CreateCategory<FanBlastingDisplay> {
     public void addWidgets(List<Widget> widgets, FanBlastingDisplay display, Rectangle bounds) {
         Point input = new Point(bounds.x + 26, bounds.y + 53);
         Point output = new Point(bounds.x + 146, bounds.y + 53);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 51, bounds.y + 32);
             AllGuiTextures.JEI_LIGHT.render(graphics, bounds.x + 70, bounds.y + 44);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/FanHauntingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/FanHauntingCategory.java
@@ -12,11 +12,11 @@ import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -78,7 +78,7 @@ public class FanHauntingCategory extends CreateCategory<FanHauntingDisplay> {
                 );
             }
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, outputs, input);
             drawChanceSlotBackground(graphics, chances);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 51, bounds.y + 32);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/FanSmokingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/FanSmokingCategory.java
@@ -11,10 +11,10 @@ import com.zurrtum.create.compat.rei.display.FanSmokingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -42,7 +42,7 @@ public class FanSmokingCategory extends CreateCategory<FanSmokingDisplay> {
     public void addWidgets(List<Widget> widgets, FanSmokingDisplay display, Rectangle bounds) {
         Point input = new Point(bounds.x + 26, bounds.y + 53);
         Point output = new Point(bounds.x + 146, bounds.y + 53);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 51, bounds.y + 32);
             AllGuiTextures.JEI_LIGHT.render(graphics, bounds.x + 70, bounds.y + 44);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/FanWashingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/FanWashingCategory.java
@@ -12,11 +12,11 @@ import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.material.Fluids;
@@ -78,7 +78,7 @@ public class FanWashingCategory extends CreateCategory<FanWashingDisplay> {
                 );
             }
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, outputs, input);
             drawChanceSlotBackground(graphics, chances);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 51, bounds.y + 32);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/ManualApplicationCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/ManualApplicationCategory.java
@@ -10,13 +10,13 @@ import com.zurrtum.create.compat.rei.display.ManualApplicationDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Slot;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
@@ -47,7 +47,7 @@ public class ManualApplicationCategory extends CreateCategory<ManualApplicationD
         Point target = new Point(bounds.x + 32, bounds.y + 43);
         Point output = new Point(bounds.x + 137, bounds.y + 43);
         Slot targetSlot = createInputSlot(target).entries(display.target());
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, target, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 67, bounds.y + 52);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 79, bounds.y + 15);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/MechanicalCraftingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/MechanicalCraftingCategory.java
@@ -10,6 +10,7 @@ import com.zurrtum.create.compat.rei.display.MechanicalCraftingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
@@ -17,7 +18,6 @@ import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.crafting.Ingredient;
 import org.joml.Matrix3x2f;
@@ -68,7 +68,7 @@ public class MechanicalCraftingCategory extends CreateCategory<MechanicalCraftin
             }
         }
         Point output = new Point(bounds.x + 138, bounds.y + 85);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, inputs, output);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 133, bounds.y + 64);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 118, bounds.y + 43);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/MillingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/MillingCategory.java
@@ -12,11 +12,11 @@ import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -73,7 +73,7 @@ public class MillingCategory extends CreateCategory<MillingDisplay> {
                 );
             }
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, outputs, input);
             drawChanceSlotBackground(graphics, chances);
             AllGuiTextures.JEI_ARROW.render(graphics, bounds.x + 90, bounds.y + 37);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/MixingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/MixingCategory.java
@@ -14,13 +14,13 @@ import com.zurrtum.create.content.processing.recipe.HeatCondition;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -52,7 +52,7 @@ public class MixingCategory extends CreateCategory<MixingDisplay> {
         }
         Point output = new Point(bounds.x + 147, bounds.y + 56);
         HeatCondition requiredHeat = display.heat();
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, points, output);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 141, bounds.y + 37);
             Matrix3x2f pose = new Matrix3x2f(graphics.pose());

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/MysteriousItemConversionCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/MysteriousItemConversionCategory.java
@@ -9,11 +9,11 @@ import com.zurrtum.create.client.foundation.utility.CreateLang;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 
 import java.util.List;
@@ -23,7 +23,7 @@ public class MysteriousItemConversionCategory extends CreateCategory<MysteriousI
     public void addWidgets(List<Widget> widgets, MysteriousItemConversionDisplay display, Rectangle bounds) {
         Point input = new Point(bounds.x + 32, bounds.y + 22);
         Point output = new Point(bounds.x + 137, bounds.y + 22);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output);
             AllGuiTextures.JEI_LONG_ARROW.render(graphics, bounds.x + 57, bounds.y + 25);
             AllGuiTextures.JEI_QUESTION_MARK.render(graphics, bounds.x + 82, bounds.y + 10);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/PotionCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/PotionCategory.java
@@ -13,12 +13,12 @@ import com.zurrtum.create.content.processing.recipe.HeatCondition;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -47,7 +47,7 @@ public class PotionCategory extends CreateCategory<PotionDisplay> {
         Point fluid = new Point(bounds.x + 45, bounds.y + 56);
         Point output = new Point(bounds.x + 147, bounds.y + 56);
         HeatCondition requiredHeat = HeatCondition.HEATED;
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, fluid, output);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 141, bounds.y + 37);
             Matrix3x2f pose = new Matrix3x2f(graphics.pose());

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/PressingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/PressingCategory.java
@@ -11,10 +11,10 @@ import com.zurrtum.create.compat.rei.display.PressingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -40,7 +40,7 @@ public class PressingCategory extends CreateCategory<PressingDisplay> {
     public void addWidgets(List<Widget> widgets, PressingDisplay display, Rectangle bounds) {
         Point input = new Point(bounds.x + 32, bounds.y + 56);
         Point output = new Point(bounds.x + 136, bounds.y + 56);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 66, bounds.y + 46);
             AllGuiTextures.JEI_LONG_ARROW.render(graphics, bounds.x + 57, bounds.y + 59);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/SandpaperPolishingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/SandpaperPolishingCategory.java
@@ -10,12 +10,12 @@ import com.zurrtum.create.compat.rei.display.SandpaperPolishingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Slot;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import org.joml.Matrix3x2f;
 
@@ -42,7 +42,7 @@ public class SandpaperPolishingCategory extends CreateCategory<SandpaperPolishin
         Point input = new Point(bounds.x + 32, bounds.y + 34);
         Point output = new Point(bounds.x + 137, bounds.y + 34);
         Slot inputSlot = createInputSlot(input).entries(display.input());
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 66, bounds.y + 26);
             AllGuiTextures.JEI_LONG_ARROW.render(graphics, bounds.x + 57, bounds.y + 37);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/SawingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/SawingCategory.java
@@ -11,10 +11,10 @@ import com.zurrtum.create.compat.rei.display.SawingDisplay;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -41,7 +41,7 @@ public class SawingCategory extends CreateCategory<SawingDisplay> {
     public void addWidgets(List<Widget> widgets, SawingDisplay display, Rectangle bounds) {
         Point input = new Point(bounds.x + 49, bounds.y + 10);
         Point output = new Point(bounds.x + 123, bounds.y + 53);
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, output);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 75, bounds.y + 11);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 60, bounds.y + 60);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/SequencedAssemblyCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/SequencedAssemblyCategory.java
@@ -19,6 +19,7 @@ import dev.architectury.fluid.FluidStack;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.*;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
@@ -95,7 +96,7 @@ public class SequencedAssemblyCategory extends CreateCategory<SequencedAssemblyD
                 if (stack != null) {
                     FluidStack fluidStack = stack.castValue();
                     fluid = fluidStack.getFluid();
-                    components = fluidStack.getComponents().asPatch();
+                    components = fluidStack.getPatch();
                 }
                 graphics.guiRenderState.addPicturesInPictureState(new SpoutRenderState(
                     i,
@@ -151,7 +152,7 @@ public class SequencedAssemblyCategory extends CreateCategory<SequencedAssemblyD
                 noBackground[i] = true;
             }
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             for (int i = 0; i < size; i++) {
                 if (noBackground[i]) {
                     continue;
@@ -193,7 +194,7 @@ public class SequencedAssemblyCategory extends CreateCategory<SequencedAssemblyD
                 slots.add(slot);
             }
         }
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             Font textRenderer = graphics.minecraft.font;
             for (int i = 0; i < size; i++) {
                 Point point = points.get(i);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/category/SpoutFillingCategory.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/category/SpoutFillingCategory.java
@@ -12,12 +12,12 @@ import dev.architectury.fluid.FluidStack;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Slot;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryStack;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import org.joml.Matrix3x2f;
@@ -50,7 +50,7 @@ public class SpoutFillingCategory extends CreateCategory<SpoutFillingDisplay> {
         Point fluid = new Point(bounds.x + 32, bounds.y + 37);
         Point output = new Point(bounds.x + 137, bounds.y + 56);
         Slot fluidSlot = createInputSlot(fluid).entries(getRenderEntryStack(display.fluid()));
-        widgets.add(Widgets.createDrawableWidget((GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) -> {
+        widgets.add(Widgets.createDrawableWidget((GuiGraphics graphics, int mouseX, int mouseY, float delta) -> {
             drawSlotBackground(graphics, input, fluid, output);
             AllGuiTextures.JEI_SHADOW.render(graphics, bounds.x + 67, bounds.y + 62);
             AllGuiTextures.JEI_DOWN_ARROW.render(graphics, bounds.x + 131, bounds.y + 34);
@@ -64,7 +64,7 @@ public class SpoutFillingCategory extends CreateCategory<SpoutFillingDisplay> {
                 i,
                 new Matrix3x2f(graphics.pose()),
                 stack.getFluid(),
-                stack.getComponents().asPatch(),
+                stack.getPatch(),
                 bounds.x + 80,
                 bounds.y + 6,
                 0

--- a/src/client/java/com/zurrtum/create/client/compat/rei/renderer/ChanceItemRenderer.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/renderer/ChanceItemRenderer.java
@@ -3,11 +3,11 @@ package com.zurrtum.create.client.compat.rei.renderer;
 import com.zurrtum.create.client.foundation.utility.CreateLang;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.entry.renderer.EntryRenderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
 import me.shedaniel.rei.api.client.gui.widgets.TooltipContext;
 import me.shedaniel.rei.api.common.entry.EntryStack;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.world.item.ItemStack;
 import org.jspecify.annotations.Nullable;
 
@@ -15,7 +15,7 @@ public record ChanceItemRenderer(float chance, EntryRenderer<ItemStack> origin) 
     @Override
     public void render(
         EntryStack<ItemStack> entry,
-        GuiGraphicsExtractor graphics,
+        GuiGraphics graphics,
         Rectangle bounds,
         int mouseX,
         int mouseY,

--- a/src/client/java/com/zurrtum/create/client/compat/rei/renderer/FluidStackRenderer.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/renderer/FluidStackRenderer.java
@@ -2,19 +2,22 @@ package com.zurrtum.create.client.compat.rei.renderer;
 
 import com.zurrtum.create.AllDataComponents;
 import com.zurrtum.create.AllFluids;
-import com.zurrtum.create.client.AllFluidConfigs;
 import com.zurrtum.create.content.fluids.potion.PotionFluidHandler;
 import com.zurrtum.create.infrastructure.component.BottleType;
 import dev.architectury.fluid.FluidStack;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.entry.renderer.EntryRenderer;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
 import me.shedaniel.rei.api.client.gui.widgets.TooltipContext;
 import me.shedaniel.rei.api.common.entry.EntryStack;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.fabricmc.fabric.api.transfer.v1.client.fluid.FluidVariantRendering;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.block.FluidModel;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.core.component.PatchedDataComponentMap;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.PotionContents;
@@ -28,7 +31,7 @@ public record FluidStackRenderer(EntryRenderer<FluidStack> origin) implements En
     @Override
     public void render(
         EntryStack<FluidStack> entry,
-        GuiGraphicsExtractor graphics,
+            GuiGraphics graphics,
         Rectangle bounds,
         int mouseX,
         int mouseY,
@@ -36,14 +39,15 @@ public record FluidStackRenderer(EntryRenderer<FluidStack> origin) implements En
     ) {
         FluidStack stack = entry.getValue();
         Fluid fluid = stack.getFluid();
-        FluidConfig config = AllFluidConfigs.get(fluid);
-        if (config == null) {
-            return;
+        FluidModel model = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluid.defaultFluidState());
+        net.minecraft.client.color.block.BlockTintSource tint = model.tintSource();
+        int color = 0xFFFFFFFF;
+        if (tint != null) {
+            color = FluidVariantRendering.getColor(FluidVariant.of(fluid, stack.getPatch())) | 0xff000000; // TODO: Potion tint colors doesn't work
         }
-        int color = config.tint().apply(stack.getComponents().asPatch()) | 0xff000000;
         graphics.blitSprite(
             RenderPipelines.GUI_TEXTURED,
-            config.still().get(),
+                model.stillMaterial().sprite(),
             bounds.x,
             bounds.y,
             bounds.width,
@@ -64,7 +68,7 @@ public record FluidStackRenderer(EntryRenderer<FluidStack> origin) implements En
         if (first.isText()) {
             FluidStack stack = entry.getValue();
             if (stack.getFluid() == AllFluids.POTION) {
-                PatchedDataComponentMap components = stack.getComponents();
+                DataComponentMap components = stack.getComponents();
                 PotionContents contents = components.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY);
                 BottleType bottleType = components.getOrDefault(
                     AllDataComponents.POTION_FLUID_BOTTLE_TYPE,
@@ -89,12 +93,14 @@ public record FluidStackRenderer(EntryRenderer<FluidStack> origin) implements En
                     scale,
                     context.vanillaContext().tickRate()
                 );
+                /* Disabled because generates double potion fluid tooltips
                 contents.addToTooltip(
                     context.vanillaContext(),
                     text -> list.add(Tooltip.entry(text)),
                     context.getFlag(),
                     components
                 );
+                 */
                 entries.removeFirst();
                 entries.addAll(0, list);
             }

--- a/src/client/java/com/zurrtum/create/client/compat/rei/renderer/TwoIconRenderer.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/renderer/TwoIconRenderer.java
@@ -2,7 +2,7 @@ package com.zurrtum.create.client.compat.rei.renderer;
 
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.Renderer;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.joml.Matrix3x2fStack;
@@ -13,7 +13,7 @@ public record TwoIconRenderer(ItemStack icon, ItemStack subIcon) implements Rend
     }
 
     @Override
-    public void render(GuiGraphicsExtractor graphics, Rectangle bounds, int mouseX, int mouseY, float delta) {
+    public void render(GuiGraphics graphics, Rectangle bounds, int mouseX, int mouseY, float delta) {
         Matrix3x2fStack matrices = graphics.pose();
         matrices.pushMatrix();
         matrices.translate(bounds.x, bounds.y);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/widget/JunkWidget.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/widget/JunkWidget.java
@@ -6,10 +6,10 @@ import me.shedaniel.clothconfig2.api.animator.NumberAnimator;
 import me.shedaniel.clothconfig2.api.animator.ValueAnimator;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.REIRuntime;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
 
@@ -36,7 +36,7 @@ public class JunkWidget extends Widget {
     }
 
     @Override
-    public void render(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
         darkHighlightedAlpha.update(delta);
         AllGuiTextures.JEI_CHANCE_SLOT.render(graphics, bounds.x - 1, bounds.y - 1);
         Component text = Component.literal("?").withStyle(ChatFormatting.BOLD);

--- a/src/client/java/com/zurrtum/create/client/compat/rei/widget/TooltipWidget.java
+++ b/src/client/java/com/zurrtum/create/client/compat/rei/widget/TooltipWidget.java
@@ -1,10 +1,10 @@
 package com.zurrtum.create.client.compat.rei.widget;
 
 import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.compat.GuiGraphics;
 import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
 import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
 import org.jspecify.annotations.Nullable;
@@ -35,7 +35,7 @@ public class TooltipWidget extends Widget {
     }
 
     @Override
-    public void render(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks) {
+    public void render(GuiGraphics context, int mouseX, int mouseY, float deltaTicks) {
         if (bounds.contains(mouseX, mouseY)) {
             Tooltip tooltip = this.tooltip.apply(minecraft);
             if (tooltip != null) {

--- a/src/main/java/com/zurrtum/create/compat/rei/IngredientHelper.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/IngredientHelper.java
@@ -81,11 +81,11 @@ public interface IngredientHelper {
         CustomIngredient customIngredient = ((FabricIngredient) ingredient).getCustomIngredient();
         if (customIngredient instanceof ComponentsIngredient) {
             EntryDefinition<ItemStack> definition = VanillaEntryTypes.ITEM.getDefinition();
-            List<SlotDisplay> contents = ((SlotDisplay.Composite) customIngredient.toDisplay()).contents();
+            List<SlotDisplay> contents = ((SlotDisplay.Composite) customIngredient.display()).contents();
             EntryIngredient.Builder builder = EntryIngredient.builder(contents.size());
             for (SlotDisplay content : contents) {
                 SlotDisplay.ItemStackSlotDisplay display = (SlotDisplay.ItemStackSlotDisplay) content;
-                builder.add(EntryStack.of(definition, display.stack()));
+                builder.add(EntryStack.of(definition, display.stack().create()));
             }
             return builder.build();
         }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/BlockCuttingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/BlockCuttingDisplay.java
@@ -77,7 +77,7 @@ public record BlockCuttingDisplay(EntryIngredient input, List<EntryIngredient> o
                 recipe.input(),
                 ingredient -> Pair.of(EntryIngredients.ofIngredient((Ingredient) ingredient), new ArrayList<>())
             );
-            display.getSecond().add(recipe.result());
+            display.getSecond().add(recipe.result().create());
         }
         for (Pair<EntryIngredient, List<ItemStack>> pair : map.values()) {
             EntryIngredient input = pair.getFirst();

--- a/src/main/java/com/zurrtum/create/compat/rei/display/CompactingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/CompactingDisplay.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.zurrtum.create.compat.rei.IngredientHelper;
 import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import com.zurrtum.create.content.kinetics.mixer.CompactingRecipe;
+import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.display.DisplaySerializer;
@@ -45,8 +46,8 @@ public record CompactingDisplay(List<EntryIngredient> inputs, EntryIngredient ou
         this(
             getEntryIngredients(
                 IngredientHelper.getSizedIngredientStream(recipe.ingredients()),
-                getFluidIngredientStream(recipe.fluidIngredient())
-            ), EntryIngredients.of(recipe.result()), Optional.of(id)
+                    IngredientHelper.getFluidIngredientStream(recipe.fluidIngredients())
+            ), EntryIngredients.ofItemStacks(recipe.results().stream().map(ProcessingOutput::create).toList()), Optional.of(id)
         );
     }
 

--- a/src/main/java/com/zurrtum/create/compat/rei/display/CrushingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/CrushingDisplay.java
@@ -69,7 +69,7 @@ public record CrushingDisplay(EntryIngredient input, List<ProcessingOutput> outp
     public List<EntryIngredient> getOutputEntries() {
         List<EntryIngredient> list = new ArrayList<>();
         for (ProcessingOutput output : outputs) {
-            list.add(EntryIngredients.of(output.stack()));
+            list.add(EntryIngredients.of(output.create()));
         }
         return list;
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/DeployingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/DeployingDisplay.java
@@ -7,6 +7,7 @@ import com.zurrtum.create.compat.rei.IngredientHelper;
 import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import com.zurrtum.create.content.equipment.sandPaper.SandPaperPolishingRecipe;
 import com.zurrtum.create.content.kinetics.deployer.ItemApplicationRecipe;
+import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.display.DisplaySerializer;
@@ -63,7 +64,7 @@ public record DeployingDisplay(EntryIngredient input, EntryIngredient target, En
         this(
             EntryIngredients.ofIngredient(recipe.ingredient()),
             IngredientHelper.getInputEntryIngredient(recipe.target()),
-            EntryIngredients.of(recipe.result()),
+            EntryIngredients.ofItemStacks(recipe.results().stream().map(ProcessingOutput::create).toList()),
             Optional.of(id)
         );
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/FanHauntingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/FanHauntingDisplay.java
@@ -53,7 +53,7 @@ public record FanHauntingDisplay(EntryIngredient input, List<ProcessingOutput> o
     public List<EntryIngredient> getOutputEntries() {
         List<EntryIngredient> list = new ArrayList<>();
         for (ProcessingOutput output : outputs) {
-            list.add(EntryIngredients.of(output.stack()));
+            list.add(EntryIngredients.of(output.create()));
         }
         return list;
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/FanWashingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/FanWashingDisplay.java
@@ -53,7 +53,7 @@ public record FanWashingDisplay(EntryIngredient input, List<ProcessingOutput> ou
     public List<EntryIngredient> getOutputEntries() {
         List<EntryIngredient> list = new ArrayList<>();
         for (ProcessingOutput output : outputs) {
-            list.add(EntryIngredients.of(output.stack()));
+            list.add(EntryIngredients.of(output.create()));
         }
         return list;
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/ManualApplicationDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/ManualApplicationDisplay.java
@@ -3,6 +3,7 @@ package com.zurrtum.create.compat.rei.display;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import com.zurrtum.create.content.kinetics.deployer.ManualApplicationRecipe;
+import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.display.DisplaySerializer;
@@ -45,7 +46,7 @@ public record ManualApplicationDisplay(EntryIngredient input, EntryIngredient ta
         this(
             EntryIngredients.ofIngredient(recipe.ingredient()),
             EntryIngredients.ofIngredient(recipe.target()),
-            EntryIngredients.of(recipe.result()),
+            EntryIngredients.ofItemStacks(recipe.results().stream().map(ProcessingOutput::create).toList()),
             Optional.of(id)
         );
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/MillingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/MillingDisplay.java
@@ -53,7 +53,7 @@ public record MillingDisplay(EntryIngredient input, List<ProcessingOutput> outpu
     public List<EntryIngredient> getOutputEntries() {
         List<EntryIngredient> list = new ArrayList<>();
         for (ProcessingOutput output : outputs) {
-            list.add(EntryIngredients.of(output.stack()));
+            list.add(EntryIngredients.of(output.create()));
         }
         return list;
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/MixingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/MixingDisplay.java
@@ -4,11 +4,13 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import com.zurrtum.create.content.kinetics.mixer.MixingRecipe;
 import com.zurrtum.create.content.processing.recipe.HeatCondition;
+import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import dev.architectury.fluid.FluidStack;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.display.DisplaySerializer;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.entry.type.VanillaEntryTypes;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -51,10 +53,9 @@ public record MixingDisplay(List<EntryIngredient> inputs, EntryIngredient output
                 getSizedIngredientStream(recipe.ingredients()),
                 getFluidIngredientStream(recipe.fluidIngredients())
             ),
-            recipe.result().isEmpty() ? EntryIngredients.of(FluidStack.create(
-                recipe.fluidResult().getFluid(),
-                recipe.fluidResult().getAmount()
-            )) : EntryIngredients.of(recipe.result()),
+            recipe.results().isEmpty() ? EntryIngredients.of(VanillaEntryTypes.FLUID, recipe.fluidResults()
+                    .stream().map(fluidStack -> FluidStack.create(fluidStack.getFluid(), fluidStack.getAmount())).toList()
+            ) : EntryIngredients.ofItemStacks(recipe.results().stream().map(ProcessingOutput::create).toList()),
             recipe.heat(),
             Optional.of(id)
         );

--- a/src/main/java/com/zurrtum/create/compat/rei/display/PressingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/PressingDisplay.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.zurrtum.create.compat.rei.IngredientHelper;
 import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import com.zurrtum.create.content.kinetics.press.PressingRecipe;
+import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.display.DisplaySerializer;
@@ -42,7 +43,7 @@ public record PressingDisplay(EntryIngredient input, EntryIngredient output,
     public PressingDisplay(Identifier id, PressingRecipe recipe) {
         this(
             IngredientHelper.getInputEntryIngredient(recipe.ingredient()),
-            EntryIngredients.of(recipe.result()),
+            EntryIngredients.ofItemStacks(recipe.results().stream().map(ProcessingOutput::create).toList()),
             Optional.of(id)
         );
     }

--- a/src/main/java/com/zurrtum/create/compat/rei/display/SawingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/SawingDisplay.java
@@ -3,6 +3,7 @@ package com.zurrtum.create.compat.rei.display;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.zurrtum.create.compat.rei.ReiCommonPlugin;
 import com.zurrtum.create.content.kinetics.saw.CuttingRecipe;
+import com.zurrtum.create.content.processing.recipe.ProcessingOutput;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.display.DisplaySerializer;
@@ -39,7 +40,7 @@ public record SawingDisplay(EntryIngredient input, EntryIngredient output,
     }
 
     public SawingDisplay(Identifier id, CuttingRecipe recipe) {
-        this(EntryIngredients.ofIngredient(recipe.ingredient()), EntryIngredients.of(recipe.result()), Optional.of(id));
+        this(EntryIngredients.ofIngredient(recipe.ingredient()), EntryIngredients.ofItemStacks(recipe.results().stream().map(ProcessingOutput::create).toList()), Optional.of(id));
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/compat/rei/display/SequencedAssemblyDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/SequencedAssemblyDisplay.java
@@ -85,7 +85,7 @@ public record SequencedAssemblyDisplay(EntryIngredient input, SequenceData seque
 
     @Override
     public List<EntryIngredient> getOutputEntries() {
-        return List.of(EntryIngredients.of(output.stack()));
+        return List.of(EntryIngredients.of(output.create()));
     }
 
     @Override

--- a/src/main/java/com/zurrtum/create/compat/rei/display/SpoutFillingDisplay.java
+++ b/src/main/java/com/zurrtum/create/compat/rei/display/SpoutFillingDisplay.java
@@ -72,7 +72,7 @@ public record SpoutFillingDisplay(EntryIngredient input, EntryIngredient fluid, 
     ) {
         List<FluidStack> fluids = fluidStream.map(entry -> {
             dev.architectury.fluid.FluidStack stack = entry.castValue();
-            return new FluidStack(stack.getFluid(), stack.getAmount(), stack.getComponents().asPatch());
+            return new FluidStack(stack.getFluid(), stack.getAmount(), stack.getPatch());
         }).toList();
         itemStream.forEach(entry -> {
             ItemStack stack = entry.castValue();

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "AbstractBoatMixin",
     "AbstractMinecartMixin",
+    "ArchitecturyMixin",
     "BlockItemMixin",
     "BlockPlaceContextMixin",
     "BlocksMixin",
@@ -80,5 +81,6 @@
     "maxShiftBy": 2,
     "defaultRequire": 1
   },
-  "mixinextras": {"minVersion": "0.5.0-beta.1"}
+  "mixinextras": {
+    "minVersion": "0.5.0-beta.1"}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,12 @@
     "create_plugin": [
       "com.zurrtum.create.AllEarlyRegistries"
     ],
+    "rei_client": [
+      "com.zurrtum.create.client.compat.rei.ReiClientPlugin"
+    ],
+    "rei_common": [
+      "com.zurrtum.create.compat.rei.ReiCommonPlugin"
+    ],
     "jei_mod_plugin": [
       "com.zurrtum.create.client.compat.jei.JeiClientPlugin"
     ],


### PR DESCRIPTION
This PR ports the existing REI compatibility to 26.2.

### Changes:
- Added REI dependencies to build.gradle. Gradle was not resolving them automatically, so I declared explicitly.
### Known issues:
- Potion fluid tint is not rendering correctly.
<img width="395" height="266" alt="image" src="https://github.com/user-attachments/assets/4ff9b4a8-b8a0-45d0-838c-24f2c4634c27" />

