### PR TITLE
Skip early PotionBrewing.bootstrap() to fix crash with Alex's Mobs Continued

### DIFF
--- a/src/main/java/com/zurrtum/create/content/kinetics/mixer/PotionRecipe.java
+++ b/src/main/java/com/zurrtum/create/content/kinetics/mixer/PotionRecipe.java
@@ -61,6 +61,18 @@ public record PotionRecipe(FluidStack result, FluidIngredient fluidIngredient,
         if (data == null) {
             return;
         }
+
+        // Temporary compatibility fix:
+        // Calling PotionBrewing.bootstrap() this early causes a
+        // "Components not bound yet" crash when Alex's Mobs (and similar mods)
+        // are present, because they create ItemStacks during bootstrap.
+        // Skip early registration for now. Potion mixing recipes will need
+        // to be generated later via a proper runtime path.
+        data = null;
+        return;
+
+        /*
+        // Original code kept for reference
         PotionBrewing potionBrewing = PotionBrewing.bootstrap(data.enabledFeatures);
         int recipeIndex = 0;
         List<Item> allowedSupportedContainers = new ArrayList<>();
@@ -120,6 +132,7 @@ public record PotionRecipe(FluidStack result, FluidIngredient fluidIngredient,
             }
         }
         data = null;
+        */
     }
 
     @Override


### PR DESCRIPTION
## Problem
Calling `PotionBrewing.bootstrap()` during early recipe registration causes a  
`NullPointerException: Components not bound yet` when Alex's Mobs Continued is installed.

## Solution
Temporarily skip the early registration of potion mixing recipes.  
This prevents the crash while keeping all other Create features working.

## Testing
- Tested with Create Fly + Alex's Mobs Continued on 26.1
- World creation no longer crashes
- Other Create features still work normally