### PR TITLE
Fix consecutive fluid transfers between inventories with different capacities

### DIFF
--- a/src/main/java/com/zurrtum/create/infrastructure/transfer/FluidInventoryStorage.java
+++ b/src/main/java/com/zurrtum/create/infrastructure/transfer/FluidInventoryStorage.java
@@ -8,7 +8,6 @@ import net.fabricmc.fabric.api.transfer.v1.storage.SlottedStorage;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.impl.transfer.DebugMessages;
 import net.minecraft.core.Direction;
-import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.jspecify.annotations.Nullable;
@@ -39,16 +38,7 @@ public interface FluidInventoryStorage extends SlottedStorage<FluidVariant> {
     }
 
     static boolean matches(FluidVariant variant, FluidStack stack) {
-        if (!variant.isOf(stack.getFluid())) {
-            return false;
-        }
-        DataComponentPatch stackComponents = stack.getComponentChanges();
-        DataComponentPatch variantComponents = variant.getComponentsPatch();
-        if (stackComponents == variantComponents) {
-            return true;
-        }
-        return stackComponents.map.reference2ObjectEntrySet()
-            .containsAll(variantComponents.map.reference2ObjectEntrySet());
+        return FluidStack.areFluidsAndComponentsEqualIgnoreCapacity(getCachedStack(variant), stack);
     }
 
     @Override


### PR DESCRIPTION
I‘ve received an [issue report](https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/494). The 128 mB observed in the linked report is one transfer batch at the configured pump speed. It is not the container's actual capacity. In the reported case, Printer appliance of my Create-Fly addon accepts the first 128 mB transfer batch and then rejects every subsequent batch. The same failure can affect other `FluidInventory` implementations exposed through Create Fly's Fabric Transfer API adapter.

So I check the codes. Create Fly stores an inventory's maximum fluid capacity in the internal `FluidStack` as the persistent and network-synchronized `FLUID_MAX_CAPACITY` data component. When a `FluidInventory` is exposed as a Fabric `Storage<FluidVariant>`, `SingleFluidStackStorage#getResource()` copies all internal fluid stack components into the exported `FluidVariant`. This means that the capacity of the source inventory becomes part of the transferred resource variant. 

For two inventories with different capacities: The source exports a `FluidVariant` containing its capacity, `sourceCapacity` and the first insertion succeeds because the target stack is empty and the resource comparison is bypassed. Also, the target inventory stores the fluid and replaces `FLUID_MAX_CAPACITY` with its own `targetCapacity`. When next batch of fluid comes in, the next insertion compares the incoming source variant against the target stack. Because the original matcher sees `sourceCapacity != targetCapacity` and treats them as different fluid resources, the insertion is rejected, even though the fluid type and every real fluid component are identical and the target still has free space.

So here is the **minimal workaround fix** to get things working for now: Use the existing capacity-agnostic fluid component comparison `FluidStack#areFluidsAndComponentsEqualIgnoreCapacity` instead of comparing the raw `DataComponentPatch` values in `FluidInventoryStorage.matches()`. This makes `FLUID_MAX_CAPACITY` non-identifying during adapter matching while continuing to compare other components. The same helper is already used by Create Fly's internal `FluidInventory` matching logic, so this change makes the Fabric storage adapter consistent with the existing inventory behavior.

I must say, in NeoForge's fluid API, a tank owns its capacity independently from its `FluidStack`. Fabric's Transfer API similarly exposes resource identity through `FluidVariant` and storage capacity through `StorageView#getCapacity()`. `FLUID_MAX_CAPACITY` should represents container metadata, not fluid resource identity. The current Create Fly port instead mirrors container capacity into the internal fluid stack, which is a wired and **risky implementation**, and certainly causes conflict acrossing third-party storages of other mods.

I still only PR a minimal workaround fix since I saw you were saying you are on a larger update on this, so to avoid imposing conflicts on your work I won''t PR a much larger fluid inventory redesign.